### PR TITLE
確認画面用のconfirmアクションを追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,4 +19,8 @@ class ItemsController < ApplicationController
 
   def destroy
   end
+
+  def confirm
+  end
+  
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
   get 'users/index'
   root 'items#index'
-  resources :items
+  resources :items do
+    collection do
+      get 'confirm'
+    end
+  end
   resources :users
 end
 


### PR DESCRIPTION
# What
商品購入確認画面用のアクションを作成

# Why
コンフリクトを避けるため、ビュー以外を触らなくていいように、あらかじめ必要なアクションを揃えておきたかったから。その中でも確認画面は７つの基本アクション以外に該当すると考えられたから。 