### PR TITLE
flashメッセージによるエラー時の文字出力

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,7 @@
 @import "modules/cards-edit";
 @import "modules/users_logout_main";
 @import "modules/users_cardbtn";
+@import "modules/flash";
 @import "modules/items";
 @import "modules/signup";
 

--- a/app/assets/stylesheets/modules/flash.scss
+++ b/app/assets/stylesheets/modules/flash.scss
@@ -1,0 +1,13 @@
+.notification {
+  .notice {
+    background-color: #2f3e51;
+    color: #fff;
+    text-align: center;
+  }
+
+  .alert {
+    background-color: #F35500;
+    color: #fff;
+    text-align: center;
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,7 +40,6 @@ class ItemsController < ApplicationController
   end
 
   def confirm
-
     if current_user.blank?
       redirect_to root_path
       flash[:alert] = 'ログインを行なってください。'

--- a/app/views/items/_items_edit.html.haml
+++ b/app/views/items/_items_edit.html.haml
@@ -59,14 +59,6 @@
                   ["トップス","2"],
                   ["ジャケット/アウター","3"],
                   ["パンツ","4"]],{},{class: "t_category_form"}
-            .t_brand
-              .t_brand_group
-                .t_brand_group__brand
-                  ブランド
-                .t_brand_group__ninni
-                  任意
-              .t_brand_style
-                = f.text_field :brand,class: "t_input_field",placeholder:"例) シャネル"
               .t_status
                 .t_status_group
                   .t_status_group__status

--- a/app/views/layouts/_notifications.html.haml
+++ b/app/views/layouts/_notifications.html.haml
@@ -1,0 +1,3 @@
+.notification
+  - flash.each do |key, value|
+    = content_tag :div, value, class: key

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,4 +9,5 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
+    = render 'layouts/notifications'
     = yield


### PR DESCRIPTION
# What
フラッシュメッセージにて、エラーや成功が出た際に文字を出力する。

# Why
エラーが出た際に、何によって登録や遷移ができなかったかがわかるようにするため。