### PR TITLE
トップページの商品一覧とマイページの出品一覧機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,9 +346,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -413,7 +410,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   unicorn

--- a/app/assets/stylesheets/modules/_toppage.scss
+++ b/app/assets/stylesheets/modules/_toppage.scss
@@ -283,12 +283,37 @@
       display: flex;
       // overflow: scroll;
       justify-content: center;
-      &__img{
-        width: 15%;
+      text-align: left;
+      a{
+        text-decoration: none;
+        color: black;
         margin: 10px;
         background-color: white;
-        &--size{
-          width: 100%;
+        height: 245px;
+        .k_picts_img{
+          width: 220px;
+          height: 150px;
+          position: relative;
+          overflow: hidden;
+          z-index: auto;
+          &__size{
+            width: 100%;
+            z-index: auto;
+            height: 150px;
+            object-fit: cover;
+          }
+        }
+        .k_picts_text{
+          padding: 16px;
+          width: 220px;
+          &__item{
+            font-size: 16px;
+            line-height: 1.5;
+            overflow: hidden;
+          }
+          &__tax{
+            font-size: 10px;
+          }
         }
         .items-box_photo__sold{
           width: 0;
@@ -299,7 +324,7 @@
           border-left: 60px solid #ea352d ;
           z-index:100;
           position: relative;
-          top:-320px;
+          top:-245px;
           &__inner{
             transform: rotate(-45deg);
             font-size: 28px;
@@ -308,6 +333,8 @@
             letter-spacing: 2px;
             font-weight: 600;
           }
+      }
+      &__img{
         }
         &__texts{
           padding: 0 16px 16px 16px;

--- a/app/assets/stylesheets/modules/_user_show.scss
+++ b/app/assets/stylesheets/modules/_user_show.scss
@@ -56,9 +56,10 @@
         padding-bottom: 5px;
       }
     }
-  
-  
+    
+    
     .h_right{
+      overflow: scroll;
       width: 700px;
       height: 100vh;
       background-color: #f8f8f8;;
@@ -82,15 +83,19 @@
             font-weight: bold;
             margin-top: 8px;
           }
-          &__list{
-            font-size: 14px;
-            display: flex;
-            margin-top: 8px;
-            &__quantity{
-              font-weight: bold;
-              padding: 0 10px 0 5px;
-            }
-          }
+        }
+      }
+      .h_items{
+        width: 700px;
+        display: flex;
+        flex-wrap: wrap;
+        text-align: center;
+        .h_items_img{
+          margin: 10px 10px 0 10px;
+        }
+        .h_items_name{
+          text-decoration: none;
+          color: black;
         }
       }
     }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,7 +13,7 @@ class ItemsController < ApplicationController
   
   def create
     @item = Item.new(items_params)
-    if @item.images[0].save
+    if @item.save(items_params)
       flash[:alert] = "アイテムを出品しました。"
     else
       render root_path

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,11 +12,10 @@ class ItemsController < ApplicationController
   
   def create
     @item = Item.new(items_params)
-    if @item.save(items_params)
-      redirect_to new_item_path
+    if @item.images[0].save
       flash[:alert] = "アイテムを出品しました。"
     else
-      render :index
+      render root_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,8 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:show,:destroy, :edit, :update]
   def index
     @item = Item.all
-    @items = Item.order("created_at DESC")
+    @items = Item.order("created_at DESC").limit(3)
+    @random = Item.order("RAND()").limit(3)
   end
   
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,8 +46,8 @@ class User < ApplicationRecord
   validates  :second_name,presence: true ,format: { with: VALID_KANJI_KANA_KATAKANA_REGEX, message:'は全角で入力してください'}
 
   # - ユーザー本名のふりがなが、名字と名前でそれぞれ必須
-  validates :hurigana_first, presence: true, length: { maximum: 35 }, format: { with: VALID_KANA_REGEX, message: 'はふりがなで入力して下さい'}
-  validates :hurigana_second, presence: true, length: { maximum: 35 }, format: { with: VALID_KANA_REGEX, message: 'はカタカナで入力して下さい'}
+  validates :hurigana_first, presence: true, length: { maximum: 35 }, format: { with: VALID_KANA_REGEX, message: 'はひらがなで入力して下さい'}
+  validates :hurigana_second, presence: true, length: { maximum: 35 }, format: { with: VALID_KANA_REGEX, message: 'はひらがなで入力して下さい'}
   # - ユーザー本名のふりがなが、全角で必須
   validates :hurigana_first, presence: true, format: { with: VALID_KANA_FUll_WIDTH, message:'は全角で入力してください'}
   validates :hurigana_second, presence: true, format: { with: VALID_KANA_FUll_WIDTH, message:'は全角で入力してください'}
@@ -93,5 +93,5 @@ class User < ApplicationRecord
 #   # /^\d{11}$/
 #   # record.errors[:name] << '電話番号は0から始まる必要があります'
 
-# end
+end
 

--- a/app/views/items/_new-items.html.haml
+++ b/app/views/items/_new-items.html.haml
@@ -1,7 +1,7 @@
 = render "items_header"
 .t_all
   .t_form_action  
-    = form_with(model:[@image,@item]) do |f|
+    = form_with(model:[@item]) do |f|
       .t_display
         .t_display__formgroup 
           .t_display_name

--- a/app/views/items/_toppage.html.haml
+++ b/app/views/items/_toppage.html.haml
@@ -98,22 +98,22 @@
       =link_to "#" do
         新規投稿商品
     .k_main__pickupContainer__picts
-      -# - @items.each do |item|
-      -#   .k_main__pickupContainer__picts__pict
-      -#     =link_to item_path(item.id) do
-
-            
-
-            -# .k_main__pickupContainer__picts__pict__img
-              -# = image_tag item.images.first.image.url,size:"220x150"
-              -# - if item.soldout == 1
-              -#   .items-box_photo__sold
-              -#     .items-box_photo__sold__inner
-              -#       SOLD
-          -# .k_main__pickupContainer__pict__img__texts
-            -# =item.nickname
-            -# .k_main__pickupContainer__pict__img__texts--size
-            -#   =item.price
+      - @items.each do |item|
+        = link_to item_path(item.id) do
+          .k_picts_img
+            = image_tag item.images[0].image.url, class:"k_picts_img__size"
+          .k_picts_text
+            .k_picts_text__item
+              = item.nickname
+            .k_picts_text__item
+              = item.price
+              円
+            .k_picts_text__tax
+              (税込)
+          - if item.soldout == 1
+            .items-box_photo__sold
+              .items-box_photo__sold__inner
+                SOLD
 
   .k_main__pickupContainer
     .k_main__pickupContainer__title
@@ -122,21 +122,22 @@
       =link_to "#" do
         アーカイバ
     .k_main__pickupContainer__picts
-      -# - @items.each do |item|
-      -#   .k_main__pickupContainer__picts__pict
-      -#     =link_to item_path(item.id) do
-
-            -# .k_main__pickupContainer__picts__pict__img
-              -# =image_tag item.images.first.image.url,size:"220x150"
-              -# - if item.soldout == 1
-              -#   .items-box_photo__sold
-              -#     .items-box_photo__sold__inner
-              -#       SOLD
-          -# .k_main__pickupContainer__pict__img__texts
-            -# =item.nickname
-            -# .k_main__pickupContainer__pict__img__texts--size
-            -#   =item.price
-    -# .k_main__pickupContainer--padding
+      - @random.each do |item|
+        = link_to item_path(item.id) do
+          .k_picts_img
+            = image_tag item.images[0].image.url, class:"k_picts_img__size"
+          .k_picts_text
+            .k_picts_text__item
+              = item.nickname
+            .k_picts_text__item
+              = item.price
+              円
+            .k_picts_text__tax
+              (税込)
+          - if item.soldout == 1
+            .items-box_photo__sold
+              .items-box_photo__sold__inner
+                SOLD
 
   .k_main__appBanner
     .k_main__appBanner__content

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -12,15 +12,12 @@
           = image_tag 'member_photo_noimage_thumb.png', class: 'h_top__icon--size'
           .h_top__icon__name
             = current_user.nickname
-          .h_top__icon__list
-            %p
-              評価
-            .h_top__icon__list__quantity
-              ０
-            %p
-              出品数
-            .h_top__icon__list__quantity
-              ０
+      .h_items
+        - current_user.items.each do |item|
+          = image_tag item.images[0].image.to_s, height: "100", width: "100"
+          = link_to item.nickname,item_path(item.id)
+          
+
 
   = render "items/items_toppage_footer"
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -14,9 +14,11 @@
             = current_user.nickname
       .h_items
         - current_user.items.each do |item|
-          = image_tag item.images[0].image.to_s, height: "100", width: "100"
-          = link_to item.nickname,item_path(item.id)
-          
+          %ul
+            %li
+              = link_to image_tag(item.images[0].image.url, height: "150", width: "150", class: "h_items_img"), item_path(item.id)
+            %li
+              = link_to item.nickname, item_path(item.id), {class: "h_items_name"}
 
 
   = render "items/items_toppage_footer"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,8 +6,8 @@ User.create!(
       nickname: 'hhhhhh',
       first_name: '田中',
       second_name: '太郎',
-      hurigana_first: 'タナカ',
-      hurigana_second: 'タロウ',
+      hurigana_first: 'たなか',
+      hurigana_second: 'たろう',
       birthday_year: "1999",
       birthday_month: "08",
       birthday_day: "16"


### PR DESCRIPTION
# What
トップページの商品一覧にて、新着とランダムで２箇所に３つづつ表示される。
マイページに出品した製品が一覧で表示される。

# Why
トップページでは購買意欲を駆り立てるため
マイページでは、出品した製品一覧を確認できる方が便利だから