### PR TITLE
商品出品エラーハンドリング

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,9 +13,9 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(items_params)
     if @item.save(items_params)
-      redirect_to new_item_path
-      flash[:alert] = "アイテムを出品しました。"
+      redirect_to  items_path(@item.id), notice: 'アイテムを出品しました。'
     else
+      flash.now[:alert] = 'アイテムの出品に失敗しました。'
       render :index
     end
   end
@@ -27,16 +27,9 @@ class ItemsController < ApplicationController
   def edit
   end
 
-  # def update
-  #   if @item.update(items_params)
-  #     redirect_to root_path
-  #   end
-  # end
   def update
     if @item.update(item_params)
       redirect_to root_path
-    else
-      render :edit
     end
   end
 

--- a/app/views/items/_new-items.html.haml
+++ b/app/views/items/_new-items.html.haml
@@ -1,7 +1,7 @@
 = render "items_header"
 .t_all
   .t_form_action  
-    = form_with(model:[@image,@item]) do |f|
+    = form_with(model:[@image,@item],data:{ remote: false }) do |f|
       .t_display
         .t_display__formgroup 
           .t_display_name

--- a/app/views/layouts/_notifications.html.haml
+++ b/app/views/layouts/_notifications.html.haml
@@ -1,5 +1,4 @@
 
-.notification
+.notification 
   - flash.each do |key, value|
     = content_tag :div, value, class: key
-


### PR DESCRIPTION
# What
商品出品のエラーハンドリング
# Why
商品が出品されたときに出品できたかできていないかを判別するため。
また出品するページがトップページに遷移させるため。