### PR TITLE
商品投稿画面のビュー崩れ解消

### DIFF
--- a/app/views/items/_items_edit.html.haml
+++ b/app/views/items/_items_edit.html.haml
@@ -60,7 +60,7 @@
                 必須
             .t_items_name__items
               .t_category-select
-                = f.collection_select :category_id, @category, :id, :name, class: "t_category-select1"
+                -# = f.collection_select :category_id, @category, :id, :name, class: "t_category-select1"
                   .listing-product-detail__category
               .t_status
                 .t_status_group

--- a/app/views/items/_new-items.html.haml
+++ b/app/views/items/_new-items.html.haml
@@ -16,10 +16,11 @@
               .t_image_field                
                 #previews
                   = f.fields_for :images do |i|
-                    .item-num-0{id: "image-box__container"}
-                      = i.file_field :image, type: 'file', name: "item[images_attributes][][image]", value:"", style: "display:none", id:"img-file"
-                      %label{for: "img-file"}
-                        %span{class: "t_input-file"} ファイルを選択
+                    - if i.index == 0
+                      .item-num-0{id: "image-box__container"}
+                        = i.file_field :image, type: 'file', name: "item[images_attributes][][image]", value:"", style: "display:none", id:"img-file"
+                        %label{for: "img-file"}
+                          %span{class: "t_input-file"} ファイルを選択
               .t_icon_camera
               .t_text_drag_drop
       .t_items

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -14,11 +14,12 @@
             = current_user.nickname
       .h_items
         - current_user.items.each do |item|
-          %ul
-            %li
-              = link_to image_tag(item.images[0].image.url, height: "150", width: "150", class: "h_items_img"), item_path(item.id)
-            %li
-              = link_to item.nickname, item_path(item.id), {class: "h_items_name"}
+          - if item.images[0].present?
+            %ul
+              %li
+                = link_to image_tag(item.images[0].image.url, height: "150", width: "150", class: "h_items_img"), item_path(item.id)
+              %li
+                = link_to item.nickname, item_path(item.id), {class: "h_items_name"}
 
 
   = render "items/items_toppage_footer"


### PR DESCRIPTION
# What
新規商品投稿にて、画像の選択画面が２つ出てしまっていたので、それを１つしか表示しないように変更。

# Why
選択画面は１つでいいから。